### PR TITLE
statistics.py: support 'checkuser' group

### DIFF
--- a/statistics.py
+++ b/statistics.py
@@ -219,6 +219,7 @@ divided by the number of days between the user's first and last edits.
         "*": "",
         "autoconfirmed": "",
         "user": "",
+        "checkuser": "",
         "bureaucrat": "[[ArchWiki:Bureaucrats|bureaucrat]]",
         "sysop": "[[ArchWiki:Administrators|administrator]]",
         "maintainer": "[[ArchWiki:Maintainers|maintainer]]",


### PR DESCRIPTION
The ArchWiki's 'checkuser' has been added to the stats table for the first time, but wiki-scripts didn't really like him (KeyError) :P
