### PR TITLE
update "API" class instantiation calls in example scripts

### DIFF
--- a/examples/diff-revisions.py
+++ b/examples/diff-revisions.py
@@ -3,17 +3,21 @@
 import os.path
 
 from ws.client import API
+from ws.client.connection import Connection
 from ws.diff import RevisionDiffer
 
 api_url = "https://wiki.archlinux.org/api.php"
+index_url = "https://wiki.arclinux.org/index.php"
 cookie_path = os.path.expanduser("~/.cache/ArchWiki.cookie")
+session = Connection.make_session(ssl_verify=True,
+                                  cookie_file=cookie_path)
 
-api = API(api_url, cookie_file=cookie_path, ssl_verify=True)
+api = API(api_url, index_url, session)
 
 
 # show the diff for two revisions, colorized for 256-color terminal
-oldrevid = 325013
-newrevid = 325254
+oldrevid = 625761
+newrevid = 625800
 
 diff = RevisionDiffer(api)
 print(diff.diff(oldrevid, newrevid))

--- a/examples/diff-revisions.py
+++ b/examples/diff-revisions.py
@@ -3,14 +3,13 @@
 import os.path
 
 from ws.client import API
-from ws.client.connection import Connection
 from ws.diff import RevisionDiffer
 
 api_url = "https://wiki.archlinux.org/api.php"
 index_url = "https://wiki.arclinux.org/index.php"
 cookie_path = os.path.expanduser("~/.cache/ArchWiki.cookie")
-session = Connection.make_session(ssl_verify=True,
-                                  cookie_file=cookie_path)
+session = API.make_session(ssl_verify=True,
+                           cookie_file=cookie_path)
 
 api = API(api_url, index_url, session)
 

--- a/examples/list-active-users.py
+++ b/examples/list-active-users.py
@@ -6,9 +6,12 @@ import datetime
 from ws.client import API
 
 api_url = "https://wiki.archlinux.org/api.php"
+index_url = "https://wiki.arclinux.org/index.php"
 cookie_path = os.path.expanduser("~/.cache/ArchWiki.cookie")
+session = API.make_session(ssl_verify=True,
+                           cookie_file=cookie_path)
 
-api = API(api_url, cookie_file=cookie_path, ssl_verify=True)
+api = API(api_url, index_url, session)
 
 # get list of all users, who:
 #   - are not bots

--- a/examples/list-allpages-by-language.py
+++ b/examples/list-allpages-by-language.py
@@ -8,9 +8,12 @@ from ws.client import API
 import ws.ArchWiki.lang as lang
 
 api_url = "https://wiki.archlinux.org/api.php"
+index_url = "https://wiki.arclinux.org/index.php"
 cookie_path = os.path.expanduser("~/.cache/ArchWiki.cookie")
+session = API.make_session(ssl_verify=True,
+                           cookie_file=cookie_path)
 
-api = API(api_url, cookie_file=cookie_path, ssl_verify=True)
+api = API(api_url, index_url, session)
 
 Page = namedtuple("Page", ["title", "langname", "pure"])
 

--- a/examples/list-generators.py
+++ b/examples/list-generators.py
@@ -5,9 +5,12 @@ import os.path
 from ws.client import API
 
 api_url = "https://wiki.archlinux.org/api.php"
+index_url = "https://wiki.arclinux.org/index.php"
 cookie_path = os.path.expanduser("~/.cache/ArchWiki.cookie")
+session = API.make_session(ssl_verify=True,
+                           cookie_file=cookie_path)
 
-api = API(api_url, cookie_file=cookie_path, ssl_verify=True)
+api = API(api_url, index_url, session)
 
 # allpages
 # see list of parameters: https://www.mediawiki.org/wiki/API:Allpages

--- a/examples/list-interwiki-links.py
+++ b/examples/list-interwiki-links.py
@@ -8,10 +8,13 @@ api_urls = [
     "https://wiki.archlinux.org/api.php",
     "https://wiki.archlinux.de/api.php",
 ]
+index_url = "https://wiki.arclinux.org/index.php"
 cookie_path = os.path.expanduser("~/.cache/ArchWiki.cookie")
+session = API.make_session(ssl_verify=True,
+                           cookie_file=cookie_path)
 
 for api_url in api_urls:
-    api = API(api_url, cookie_file=cookie_path, ssl_verify=True)
+    api = API(api_url, index_url, session)
     prefixes = set()
     for ns in api.site.namespaces:
         if ns < 0:


### PR DESCRIPTION
Hi. It looks like my very first commit belongs to you. :-)
I started my research on wiki-scripts and found out, that "diff-revisions.py" example is not working because of API class constructor interface was changed.
More commits are coming. (: