### PR TITLE
example-config.py: fix the argument list in getArgParser call

### DIFF
--- a/examples/example-config.py
+++ b/examples/example-config.py
@@ -3,7 +3,7 @@
 import ws.config
 
 if __name__ == "__main__":
-    argparser = ws.config.getArgParser(name="example", description="Simple example")
+    argparser = ws.config.getArgParser(description="Simple example")
 
     argparser.add_argument("--foo", help="foo option")
 


### PR DESCRIPTION
Running `python example/example-config.py` results in the following output:

```python
Traceback (most recent call last):
  File "examples/example-config.py", line 6, in <module>
    argparser = ws.config.getArgParser(name="example", description="Simple example")
  File "/home/alex/code/wiki-scripts/ws/config.py", line 137, in getArgParser
    ap = configargparse.ArgParser(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'name'
```

The `getArgParser` function, stored in the `ws.config` module, has no `name` argument anymore. It was replaced with the `subname` argument which is set to `None` by default.

I delete the unnecessary argument. Running `grep -Fr 'getArgParser' .` in the project root shows that there is no other erroneous functions, so this seems to be the only one.

Otherwise, everything looks like the scripts in the `examples` directory are quite functional. Only the `list-unwatched-pages.py` script does not work because I have no enough rights to use it:

```
The current user does not have the 'unwatchedpages' right, which is necessary to use this script. Sorry.
```

Because of he says "Sorry" I will not try to punish him. :-)
