### PR TITLE
ExtlinkReplacements: add more and fix (projects|git).archlinux.org replacements

### DIFF
--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -138,10 +138,10 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
 
         # other git repos
         ("update old (projects|git).archlinux.org links",
-            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>archboot|archiso|aurweb|infrastructure|initscripts|namcap|netcfg|netctl|pacman|srcpac).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
+            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>abs|archboot|archiso|aurweb|infrastructure|initscripts|namcap|netcfg|netctl|pacman|srcpac).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
             "https://gitlab.archlinux.org/{% if project == 'archboot' %}tpowa{% elif project in [ 'pacman', 'namcap' ] %}pacman{% else %}archlinux{% endif %}/{{project}}{% if type is not none %}/{{type | replace('plain', 'raw') | replace('log', 'commits')}}{% if commit is not none %}/{{commit}}{% elif branch is not none %}/{{branch}}{% elif path is not none %}/master{% endif %}{% if (path is not none) and (path != '/') %}{{path}}{% endif %}{% if linenum is not none %}#L{{linenum}}{% endif %}{% endif %}"),
         ("update old (projects|git).archlinux.org links",
-            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>abs|arch-install-scripts|archweb|linux|mkinitcpio|vhosts\/wiki\.archlinux\.org).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
+            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>arch-install-scripts|archweb|dbscripts|devtools|linux|mkinitcpio|vhosts\/wiki\.archlinux\.org).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
             "https://github.com/archlinux/{{project | replace ('vhosts/wiki.archlinux.org', 'archwiki')}}{% if type is not none %}/{{type | replace('plain', 'raw') | replace('log', 'commits')}}{% if commit is not none %}/{{commit}}{% elif branch is not none %}/{{branch}}{% elif path is not none %}/master{% endif %}{% if (path is not none) and (path != '/') %}{{path}}{% endif %}{% if linenum is not none %}#L{{linenum}}{% endif %}{% endif %}"),
         # TODO: github.com/archlinux/ to gitlab.archlinux.org
         # the only difference should be line selection. GitHub uses #L10-L15 while GitLab uses #L10-15


### PR DESCRIPTION
* abs moved to gitlab.archlinux.org
* dbscripts and devtools moved to GitHub