### PR TITLE
ExtlinkReplacements: remove .php from aurweb URLs

### DIFF
--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -121,6 +121,11 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
             r"https?\:\/\/www\.archlinux\.org(?P<path>\/.*)?",
             "https://archlinux.org{% if path is not none %}{{path}}{% endif %}"),
 
+        # aurweb
+        ("remove .php from aurweb URLs",
+            r"https?\:\/\/aur\.archlinux\.org\/(?P<path>packages|rpc|index)\.php\/?(?P<params>.*)?",
+            "https://aur.archlinux.org/{% if path != 'index' %}{{path}}{% endif %}{% if params is not none %}{{params}}{% endif %}"),
+
         # migration of Arch's git URLs
 
         # svntogit commits


### PR DESCRIPTION
aurweb is not PHP-based anymore and these `.php` links are dead.