### PR TITLE
ExtlinkReplacements: catch lists.archlinux.org links that do not link to a specific mailing list

### DIFF
--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -105,11 +105,11 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
 
         # mailman
         ("update old mailman URLs from (lists|mailman).archlinux.org/listinfo/ to lists.archlinux.org/mailman3/lists/",
-            r"https?\:\/\/(?:lists\.|mailman\.|www\.)?archlinux\.org(\/mailman)?\/\/?listinfo\/(?P<mailinglist>[\w-]+)\/?",
-            "https://lists.archlinux.org/mailman3/lists/{% if mailinglist is not none %}{{mailinglist}}.lists.archlinux.org/{% endif %}"),
+            r"https?\:\/\/(?:lists\.|mailman\.|www\.)?archlinux\.org(\/mailman)?\/\/?listinfo(?P<mailinglist>\/[\w-]+)?\/?",
+            "https://lists.archlinux.org/mailman3/lists{% if mailinglist is not none %}{{mailinglist}}.lists.archlinux.org{% endif %}/"),
         ("update old mailman URLs from (lists|mailman).archlinux.org/pipermail/ to lists.archlinux.org/archives/",
-            r"https?\:\/\/(?:lists\.|mailman\.|www\.)?archlinux\.org\/pipermail\/(?P<mailinglist>[\w-]+)\/?",
-            "https://lists.archlinux.org/archives/{% if mailinglist is not none %}list/{{mailinglist}}@lists.archlinux.org/{% endif %}"),
+            r"https?\:\/\/(?:lists\.|mailman\.|www\.)?archlinux\.org\/pipermail(?P<mailinglist>\/[\w-]+)?\/?",
+            "https://lists.archlinux.org/archives/{% if mailinglist is not none %}list{{mailinglist}}@lists.archlinux.org/{% endif %}"),
 
         # ancient php pages
         ("update ancient archweb URLs from archlinux.org/*.php to archlinux.org/*/",


### PR DESCRIPTION
Fixes 3ce1c59c1d6a50f5c476fa1aa998e714d7ada8f6.