### PR TITLE
ExtlinkReplacements: use https://docs.kernel.org/ instead of https://www.kernel.org/doc/html/latest/ in link replacements

### DIFF
--- a/tests/checkers/ExtlinkReplacements/url_replacements_kernel.org.feature
+++ b/tests/checkers/ExtlinkReplacements/url_replacements_kernel.org.feature
@@ -14,24 +14,24 @@ Feature: ExtlinkReplacements: kernel.org links
         | foo [{} baz] bar |
 
     Scenario Outline: kernel.org fbcon.txt
-        Given the URL https://www.kernel.org/doc/html/latest/fb/fbcon.html gives status 200
+        Given the URL https://docs.kernel.org/fb/fbcon.html gives status 200
         When a page contains <pattern> formatted with https://www.kernel.org/doc/Documentation/fb/fbcon.txt
         And I run ExtlinkReplacements
-        Then the page content should be "<pattern>" formatted with "https://www.kernel.org/doc/html/latest/fb/fbcon.html"
+        Then the page content should be "<pattern>" formatted with "https://docs.kernel.org/fb/fbcon.html"
         And the last edit summary should be "link to HTML version of kernel documentation"
 
     Scenario Outline: kernel.org fbcon.rst
-        Given the URL https://www.kernel.org/doc/html/latest/fb/fbcon.html gives status 200
+        Given the URL https://docs.kernel.org/fb/fbcon.html gives status 200
         When a page contains <pattern> formatted with https://www.kernel.org/doc/Documentation/fb/fbcon.rst
         And I run ExtlinkReplacements
-        Then the page content should be "<pattern>" formatted with "https://www.kernel.org/doc/html/latest/fb/fbcon.html"
+        Then the page content should be "<pattern>" formatted with "https://docs.kernel.org/fb/fbcon.html"
         And the last edit summary should be "link to HTML version of kernel documentation"
 
     Scenario Outline: kernel.org fb directory
-        Given the URL https://www.kernel.org/doc/html/latest/fb/ gives status 200
+        Given the URL https://docs.kernel.org/fb/ gives status 200
         When a page contains <pattern> formatted with https://www.kernel.org/doc/Documentation/fb/
         And I run ExtlinkReplacements
-        Then the page content should be "<pattern>" formatted with "https://www.kernel.org/doc/html/latest/fb/"
+        Then the page content should be "<pattern>" formatted with "https://docs.kernel.org/fb/"
         And the last edit summary should be "link to HTML version of kernel documentation"
 
     Scenario Outline: not replacing excluded kernel.org link

--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -168,6 +168,9 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
         ("link to HTML version of kernel documentation",
             r"https?\:\/\/(?:www\.)?kernel.org/doc/Documentation(?P<path>\/.+?)(?P<extension>\.txt|\.rst)?",
             "https://docs.kernel.org{{path}}{% if extension is not none %}.html{% endif %}"),
+        ("link to the kernel documentation on docs.kernel.org",
+            r"https?\:\/\/(?:www\.)?kernel\.org\/doc\/html\/[^\/]+(?P<path>\/.*)?",
+            "https://docs.kernel.org{% if path is not none %}{{path}}{% endif %}"),
 
         # wireless.wiki.kernel.org
         ("update linuxwireless.org/wireless.kernel.org links",

--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -164,11 +164,6 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
             r"https?\:\/\/addons\.mozilla\.org/(?P<application>thunderbird|seamonkey)(?P<path>.+)?",
             "https://addons.thunderbird.net/{{application}}{% if path is not none %}{{path}}{% endif %}"),
 
-        # exclude the replacement of specific links
-        (None,
-            "https://www.kernel.org/doc/Documentation/filesystems/",
-            "https://www.kernel.org/doc/Documentation/filesystems/"),
-
         # kernel.org documentation links
         ("link to HTML version of kernel documentation",
             r"https?\:\/\/(?:www\.)?kernel.org/doc/Documentation(?P<path>\/.+?)(?P<extension>\.txt|\.rst)?",

--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -172,7 +172,7 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
         # kernel.org documentation links
         ("link to HTML version of kernel documentation",
             r"https?\:\/\/(?:www\.)?kernel.org/doc/Documentation(?P<path>\/.+?)(?P<extension>\.txt|\.rst)?",
-            "https://www.kernel.org/doc/html/latest{{path}}{% if extension is not none %}.html{% endif %}"),
+            "https://docs.kernel.org{{path}}{% if extension is not none %}.html{% endif %}"),
 
         # wireless.wiki.kernel.org
         ("update linuxwireless.org/wireless.kernel.org links",


### PR DESCRIPTION
https://www.kernel.org/ links to https://docs.kernel.org/ for documentation and the URL is shorter.

See https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=ebc1c372850f249dd143c6d942e66c88ec610520.