### PR TITLE
ExtlinkReplacements: update mkinitcpio URLs

### DIFF
--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -151,6 +151,9 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
 
         # projects that moved from github.com/archlinux/ or are mirrored there
         ("change Arch project URLs from github.com to gitlab.archlinux.org",
+             r"https?\:\/\/github\.com\/archlinux\/(?P<repo>arch-boxes|arch-historical-archive|arch-rebuild-order|arch-repo-management|arch-signoff|archbbs|archiso|archivetools|asknot-ng|conf\.archlinux\.org|mkinitcpio|rebuilder|sandcrawler|signstar)(?P<git>\.git)?",
+             "https://gitlab.archlinux.org/archlinux/{% if repo == 'mkinitcpio' %}mkinitcpio/{% endif %}{{repo | replace ('conf.archlinux.org', 'conf') | replace ('rebuilder' , 'arch-rebuild-order')}}{% if git is not none %}{{git}}{% endif %}"),
+        ("change Arch project URLs from github.com to gitlab.archlinux.org",
              r"https?\:\/\/github\.com\/archlinux\/(?P<repo>arch-boxes|arch-historical-archive|arch-rebuild-order|arch-repo-management|arch-signoff|archbbs|archiso|archivetools|asknot-ng|conf\.archlinux\.org|mkinitcpio|rebuilder|sandcrawler|signstar)(?:\.git)?\/commit\/(?P<commit>[0-9A-Fa-f]+)",
              "https://gitlab.archlinux.org/archlinux/{% if repo == 'mkinitcpio' %}mkinitcpio/{% endif %}{{repo | replace ('conf.archlinux.org', 'conf') | replace ('rebuilder' , 'arch-rebuild-order')}}/commit/{{commit}}"),
         # TODO: blobs, history (/commits/), raw (including raw.githubusercontent.com)

--- a/ws/checkers/ExtlinkReplacements.py
+++ b/ws/checkers/ExtlinkReplacements.py
@@ -143,16 +143,16 @@ class ExtlinkReplacements(ExtlinkStatusChecker):
 
         # other git repos
         ("update old (projects|git).archlinux.org links",
-            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>abs|archboot|archiso|aurweb|infrastructure|initscripts|namcap|netcfg|netctl|pacman|srcpac).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
-            "https://gitlab.archlinux.org/{% if project == 'archboot' %}tpowa{% elif project in [ 'pacman', 'namcap' ] %}pacman{% else %}archlinux{% endif %}/{{project}}{% if type is not none %}/{{type | replace('plain', 'raw') | replace('log', 'commits')}}{% if commit is not none %}/{{commit}}{% elif branch is not none %}/{{branch}}{% elif path is not none %}/master{% endif %}{% if (path is not none) and (path != '/') %}{{path}}{% endif %}{% if linenum is not none %}#L{{linenum}}{% endif %}{% endif %}"),
+            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>abs|archboot|archiso|aurweb|infrastructure|initscripts|mkinitcpio|namcap|netcfg|netctl|pacman|srcpac).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
+            "https://gitlab.archlinux.org/{% if project == 'archboot' %}tpowa{% elif project in [ 'pacman', 'namcap' ] %}pacman{% else %}archlinux{% endif %}{% if project == 'mkinitcpio' %}/mkinitcpio{% endif %}/{{project}}{% if type is not none %}/{{type | replace('plain', 'raw') | replace('log', 'commits')}}{% if commit is not none %}/{{commit}}{% elif branch is not none %}/{{branch}}{% elif path is not none %}/master{% endif %}{% if (path is not none) and (path != '/') %}{{path}}{% endif %}{% if linenum is not none %}#L{{linenum}}{% endif %}{% endif %}"),
         ("update old (projects|git).archlinux.org links",
-            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>arch-install-scripts|archweb|dbscripts|devtools|linux|mkinitcpio|vhosts\/wiki\.archlinux\.org).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
+            r"https?\:\/\/(?:projects|git)\.archlinux\.org\/(?P<project>arch-install-scripts|archweb|dbscripts|devtools|linux|vhosts\/wiki\.archlinux\.org).git(?:\/(?P<type>commit|tree|plain|log))?(?P<path>[^?]+?)?(?:\?h=(?P<branch>[^&#?]+?))?(?:[&?]id=(?P<commit>[0-9A-Ha-f]+))?(?:#n(?P<linenum>\d+))?",
             "https://github.com/archlinux/{{project | replace ('vhosts/wiki.archlinux.org', 'archwiki')}}{% if type is not none %}/{{type | replace('plain', 'raw') | replace('log', 'commits')}}{% if commit is not none %}/{{commit}}{% elif branch is not none %}/{{branch}}{% elif path is not none %}/master{% endif %}{% if (path is not none) and (path != '/') %}{{path}}{% endif %}{% if linenum is not none %}#L{{linenum}}{% endif %}{% endif %}"),
 
         # projects that moved from github.com/archlinux/ or are mirrored there
         ("change Arch project URLs from github.com to gitlab.archlinux.org",
-             r"https?\:\/\/github\.com\/archlinux\/(?P<repo>arch-boxes|arch-historical-archive|arch-rebuild-order|arch-repo-management|arch-signoff|archbbs|archiso|archivetools|asknot-ng|conf\.archlinux\.org|rebuilder|sandcrawler|signstar)(?:\.git)?\/commit\/(?P<commit>[0-9A-Fa-f]+)",
-             "https://gitlab.archlinux.org/archlinux/{{repo | replace ('conf.archlinux.org', 'conf') | replace ('rebuilder' , 'arch-rebuild-order')}}/commit/{{commit}}"),
+             r"https?\:\/\/github\.com\/archlinux\/(?P<repo>arch-boxes|arch-historical-archive|arch-rebuild-order|arch-repo-management|arch-signoff|archbbs|archiso|archivetools|asknot-ng|conf\.archlinux\.org|mkinitcpio|rebuilder|sandcrawler|signstar)(?:\.git)?\/commit\/(?P<commit>[0-9A-Fa-f]+)",
+             "https://gitlab.archlinux.org/archlinux/{% if repo == 'mkinitcpio' %}mkinitcpio/{% endif %}{{repo | replace ('conf.archlinux.org', 'conf') | replace ('rebuilder' , 'arch-rebuild-order')}}/commit/{{commit}}"),
         # TODO: blobs, history (/commits/), raw (including raw.githubusercontent.com)
         # NOTE: for line selection GitHub uses #L10-L15 while GitLab uses #L10-15
 


### PR DESCRIPTION
* update mkinitcpio commit URLs now that the project has moved to gitlab.archlinux.org
* update project URLs (plain links to the project or to .git) from github.com to gitlab.archlinux.org